### PR TITLE
Change data members of main structure to array for better API usability

### DIFF
--- a/zklaim/main.c
+++ b/zklaim/main.c
@@ -68,29 +68,29 @@ int worker() {
     printf("[ISSUER] Setting up payloads..\n");
     zklaim_payload pl, pl2;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 1;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 2;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 3;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 1;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 2;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 3;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     memset(&pl2, 0, sizeof(zklaim_payload));
-    pl2.data0_ref = 0;
-    pl2.data0_op = zklaim_noop;
-    pl2.data1_ref = 0;
-    pl2.data1_op = zklaim_noop;
-    pl2.data2_ref = 0;
-    pl2.data2_op = zklaim_noop;
-    pl2.data3_ref = 0;
-    pl2.data3_op = zklaim_noop;
-    pl2.data4_ref = 9223372036854775807;
-    pl2.data4_op = zklaim_less_or_eq;
+    pl2.data_ref[0] = 0;
+    pl2.data_op[0] = zklaim_noop;
+    pl2.data_ref[1] = 0;
+    pl2.data_op[1] = zklaim_noop;
+    pl2.data_ref[2] = 0;
+    pl2.data_op[2] = zklaim_noop;
+    pl2.data_ref[3] = 0;
+    pl2.data_op[3] = zklaim_noop;
+    pl2.data_ref[4] = 9223372036854775807;
+    pl2.data_op[4] = zklaim_less_or_eq;
     pl2.priv = 0;
 
     // fill in the values
@@ -191,21 +191,21 @@ int worker() {
     memcpy(ctx_prover->pk, ctx->pk, ctx_prover->pk_size);
 
     // set custom prover reference values here:
-    ctx_prover->pl_ctx_head->pl.data0_ref = 20;
-    /* ctx_prover->pl_ctx_head->next->pl.data0_ref = 30; */
-    /* ctx_prover->pl_ctx_head->next->pl.data0_op = zklaim_less_or_eq; */
-    //ctx_prover->pl_ctx_head->pl.data0_op = zklaim_less;
-    ctx_prover->pl_ctx_head->pl.data4_ref = 0;
-    ctx_prover->pl_ctx_head->pl.data4_op = zklaim_noop;
+    ctx_prover->pl_ctx_head->pl.data_ref[0] = 20;
+    /* ctx_prover->pl_ctx_head->next->pl.data_ref[0] = 30; */
+    /* ctx_prover->pl_ctx_head->next->pl.data_op[0] = zklaim_less_or_eq; */
+    //ctx_prover->pl_ctx_head->pl.data_op[0] = zklaim_less;
+    ctx_prover->pl_ctx_head->pl.data_ref[4] = 0;
+    ctx_prover->pl_ctx_head->pl.data_op[4] = zklaim_noop;
 
-    ctx_prover->pl_ctx_head->pl.data1_ref = 0;
-    ctx_prover->pl_ctx_head->pl.data1_op = zklaim_noop;
+    ctx_prover->pl_ctx_head->pl.data_ref[1] = 0;
+    ctx_prover->pl_ctx_head->pl.data_op[1] = zklaim_noop;
 
-    ctx_prover->pl_ctx_head->pl.data2_ref = 0;
-    ctx_prover->pl_ctx_head->pl.data2_op = zklaim_noop;
+    ctx_prover->pl_ctx_head->pl.data_ref[2] = 0;
+    ctx_prover->pl_ctx_head->pl.data_op[2] = zklaim_noop;
 
-    ctx_prover->pl_ctx_head->pl.data3_ref = 0;
-    ctx_prover->pl_ctx_head->pl.data3_op = zklaim_noop;
+    ctx_prover->pl_ctx_head->pl.data_ref[3] = 0;
+    ctx_prover->pl_ctx_head->pl.data_op[3] = zklaim_noop;
 
     zklaim_print(ctx_prover);
 

--- a/zklaim/main_benchmark.c
+++ b/zklaim/main_benchmark.c
@@ -62,29 +62,29 @@ int worker(int k) {
      */
     zklaim_payload pl, pl2;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 1;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 2;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 3;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 1;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 2;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 3;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     memset(&pl2, 0, sizeof(zklaim_payload));
-    pl2.data0_ref = 0;
-    pl2.data0_op = zklaim_noop;
-    pl2.data1_ref = 0;
-    pl2.data1_op = zklaim_noop;
-    pl2.data2_ref = 0;
-    pl2.data2_op = zklaim_noop;
-    pl2.data3_ref = 0;
-    pl2.data3_op = zklaim_noop;
-    pl2.data4_ref = 9223372036854775807;
-    pl2.data4_op = zklaim_less_or_eq;
+    pl2.data_ref[0] = 0;
+    pl2.data_op[0] = zklaim_noop;
+    pl2.data_ref[1] = 0;
+    pl2.data_op[1] = zklaim_noop;
+    pl2.data_ref[2] = 0;
+    pl2.data_op[2] = zklaim_noop;
+    pl2.data_ref[3] = 0;
+    pl2.data_op[3] = zklaim_noop;
+    pl2.data_ref[4] = 9223372036854775807;
+    pl2.data_op[4] = zklaim_less_or_eq;
     pl2.priv = 0;
 
     // fill in the values
@@ -119,19 +119,19 @@ int worker(int k) {
     zklaim_ctx_sign(ctx, priv);
 
     // set custom prover reference values here:
-    ctx->pl_ctx_head->pl.data0_ref = 20;
-    //ctx_prover->pl_ctx_head->pl.data0_op = zklaim_less;
-    ctx->pl_ctx_head->pl.data4_ref = 0;
-    ctx->pl_ctx_head->pl.data4_op = zklaim_noop;
+    ctx->pl_ctx_head->pl.data_ref[0] = 20;
+    //ctx_prover->pl_ctx_head->pl.data_op[0] = zklaim_less;
+    ctx->pl_ctx_head->pl.data_ref[4] = 0;
+    ctx->pl_ctx_head->pl.data_op[4] = zklaim_noop;
 
-    ctx->pl_ctx_head->pl.data1_ref = 0;
-    ctx->pl_ctx_head->pl.data1_op = zklaim_noop;
+    ctx->pl_ctx_head->pl.data_ref[1] = 0;
+    ctx->pl_ctx_head->pl.data_op[1] = zklaim_noop;
 
-    ctx->pl_ctx_head->pl.data2_ref = 0;
-    ctx->pl_ctx_head->pl.data2_op = zklaim_noop;
+    ctx->pl_ctx_head->pl.data_ref[2] = 0;
+    ctx->pl_ctx_head->pl.data_op[2] = zklaim_noop;
 
-    ctx->pl_ctx_head->pl.data3_ref = 0;
-    ctx->pl_ctx_head->pl.data3_op = zklaim_noop;
+    ctx->pl_ctx_head->pl.data_ref[3] = 0;
+    ctx->pl_ctx_head->pl.data_op[3] = zklaim_noop;
 
     clock_gettime(CLOCK_THREAD_CPUTIME_ID,&t);
     zklaim_proof_generate(ctx);

--- a/zklaim/tests/zklaim.cpp
+++ b/zklaim/tests/zklaim.cpp
@@ -11,16 +11,16 @@ TEST(zklaim, can_create_ctx) {
 TEST(zklaim, can_create_and_add_pl) {
     zklaim_payload pl;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_ctx *ctx = zklaim_context_new();
@@ -32,16 +32,16 @@ TEST(zklaim, can_create_and_add_pl) {
 TEST(zklaim, can_do_ts) {
     zklaim_payload pl;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_ctx *ctx = zklaim_context_new();
@@ -61,16 +61,16 @@ TEST(zklaim, can_sign) {
     zklaim_gen_pk(&priv);
 
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_ctx *ctx = zklaim_context_new();
@@ -102,29 +102,29 @@ TEST(zklaim, can_detect_invalid_signature) {
 
     zklaim_payload pl, pl2;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     memset(&pl2, 0, sizeof(zklaim_payload));
-    pl2.data0_ref = 0;
-    pl2.data0_op = zklaim_noop;
-    pl2.data1_ref = 0;
-    pl2.data1_op = zklaim_noop;
-    pl2.data2_ref = 0;
-    pl2.data2_op = zklaim_noop;
-    pl2.data3_ref = 0;
-    pl2.data3_op = zklaim_noop;
-    pl2.data4_ref = 9223372036854775807;
-    pl2.data4_op = zklaim_less_or_eq;
+    pl2.data_ref[0] = 0;
+    pl2.data_op[0] = zklaim_noop;
+    pl2.data_ref[1] = 0;
+    pl2.data_op[1] = zklaim_noop;
+    pl2.data_ref[2] = 0;
+    pl2.data_op[2] = zklaim_noop;
+    pl2.data_ref[3] = 0;
+    pl2.data_op[3] = zklaim_noop;
+    pl2.data_ref[4] = 9223372036854775807;
+    pl2.data_op[4] = zklaim_less_or_eq;
     pl2.priv = 0;
 
     zklaim_set_attr(&pl, 18, 0);
@@ -159,7 +159,7 @@ TEST(zklaim, can_detect_invalid_signature) {
     ctx_prover->pk_size = ctx->pk_size;
     memcpy(ctx_prover->pk, ctx->pk, ctx_prover->pk_size);
 
-    ctx_prover->pl_ctx_head->pl.data0_ref = 19;
+    ctx_prover->pl_ctx_head->pl.data_ref[0] = 19;
     zklaim_hash_ctx(ctx_prover);
 
     zklaim_clear_pres(ctx_prover);
@@ -191,16 +191,16 @@ TEST(zklaim, can_verify) {
     zklaim_pub2buf(pub, &pubbuf, &publen);
 
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
 
@@ -226,16 +226,16 @@ TEST(zklaim, can_proof) {
     zklaim_gen_pk(&priv);
 
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_set_attr(&pl, 18, 0);
@@ -264,16 +264,16 @@ TEST(zklaim, can_handle_two_payloads) {
     zklaim_gen_pk(&priv);
 
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_set_attr(&pl, 18, 0);
@@ -304,16 +304,16 @@ TEST(zklaim, can_handle_three_payloads) {
     zklaim_gen_pk(&priv);
 
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_set_attr(&pl, 18, 0);
@@ -372,16 +372,16 @@ TEST(DISABLED_zklaim, rejects_invalid_proof) {
 TEST(zklaim, preimage_and_salt_get_cleared) {
     zklaim_payload pl;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     zklaim_set_attr(&pl, 18, 0);
@@ -428,29 +428,29 @@ TEST(zklaim, three_party_run) {
 
     zklaim_payload pl, pl2;
     memset(&pl, 0, sizeof(zklaim_payload));
-    pl.data0_ref = 18;
-    pl.data0_op = (enum zklaim_op) (zklaim_greater | zklaim_eq);
-    pl.data1_ref = 0;
-    pl.data1_op = zklaim_eq;
-    pl.data2_ref = 0;
-    pl.data2_op = zklaim_eq;
-    pl.data3_ref = 0;
-    pl.data3_op = zklaim_eq;
-    pl.data4_ref = 600;
-    pl.data4_op = zklaim_less;
+    pl.data_ref[0] = 18;
+    pl.data_op[0] = (enum zklaim_op) (zklaim_greater | zklaim_eq);
+    pl.data_ref[1] = 0;
+    pl.data_op[1] = zklaim_eq;
+    pl.data_ref[2] = 0;
+    pl.data_op[2] = zklaim_eq;
+    pl.data_ref[3] = 0;
+    pl.data_op[3] = zklaim_eq;
+    pl.data_ref[4] = 600;
+    pl.data_op[4] = zklaim_less;
     pl.priv = 0;
 
     memset(&pl2, 0, sizeof(zklaim_payload));
-    pl2.data0_ref = 0;
-    pl2.data0_op = zklaim_noop;
-    pl2.data1_ref = 0;
-    pl2.data1_op = zklaim_noop;
-    pl2.data2_ref = 0;
-    pl2.data2_op = zklaim_noop;
-    pl2.data3_ref = 0;
-    pl2.data3_op = zklaim_noop;
-    pl2.data4_ref = 9223372036854775807;
-    pl2.data4_op = zklaim_less_or_eq;
+    pl2.data_ref[0] = 0;
+    pl2.data_op[0] = zklaim_noop;
+    pl2.data_ref[1] = 0;
+    pl2.data_op[1] = zklaim_noop;
+    pl2.data_ref[2] = 0;
+    pl2.data_op[2] = zklaim_noop;
+    pl2.data_ref[3] = 0;
+    pl2.data_op[3] = zklaim_noop;
+    pl2.data_ref[4] = 9223372036854775807;
+    pl2.data_op[4] = zklaim_less_or_eq;
     pl2.priv = 0;
 
     zklaim_set_attr(&pl, 18, 0);

--- a/zklaim/zklaim.c
+++ b/zklaim/zklaim.c
@@ -156,32 +156,28 @@ void zklaim_print(zklaim_ctx *ctx){
     // primarily print payloads!
     zklaim_wrap_payload_ctx *cur = ctx->pl_ctx_head;
     size_t counter = 0;
-    uint64_t data0, data1, data2, data3, data4, salt;
+    uint64_t data[ZKLAIM_MAX_PAYLOAD_ATTRIBUTES];
+    uint64_t salt;
+    int i;
     while (cur != NULL) {
         // recover data
-        memcpy(&data0, cur->pl.pre, 8);
-        memcpy(&data1, cur->pl.pre+8, 8);
-        memcpy(&data2, cur->pl.pre+16, 8);
-        memcpy(&data3, cur->pl.pre+24, 8);
-        memcpy(&data4, cur->pl.pre+32, 8);
+        memcpy(&data[0], cur->pl.pre, 8);
+        memcpy(&data[1], cur->pl.pre+8, 8);
+        memcpy(&data[2], cur->pl.pre+16, 8);
+        memcpy(&data[3], cur->pl.pre+24, 8);
+        memcpy(&data[4], cur->pl.pre+32, 8);
         memcpy(&salt, cur->pl.pre+40, 8);
         printf("======================================================================\n");
         printf("=======          viewing information about payload #%zu          =======\n", counter);
         printf("======================================================================\n");
         printf("Format: [actual] op reference\n");
         if (cur->pl.priv != 1) {
-            printf("data%i: [%"PRIu64"] %s %"PRIu64"\n", 0, data0, zklaim_parse_op(cur->pl.data0_op), cur->pl.data0_ref);
-            printf("data%i: [%"PRIu64"] %s %"PRIu64"\n", 1, data1, zklaim_parse_op(cur->pl.data1_op), cur->pl.data1_ref);
-            printf("data%i: [%"PRIu64"] %s %"PRIu64"\n", 2, data2, zklaim_parse_op(cur->pl.data2_op), cur->pl.data2_ref);
-            printf("data%i: [%"PRIu64"] %s %"PRIu64"\n", 3, data3, zklaim_parse_op(cur->pl.data3_op), cur->pl.data3_ref);
-            printf("data%i: [%"PRIu64"] %s %"PRIu64"\n", 4, data4, zklaim_parse_op(cur->pl.data4_op), cur->pl.data4_ref);
+            for (int i = 0; i < ZKLAIM_MAX_PAYLOAD_ATTRIBUTES; i++)
+                printf("data%i: [%"PRIu64"] %s %"PRIu64"\n", i, data[i], zklaim_parse_op(cur->pl.data_op[i]), cur->pl.data_ref[i]);
             printf("payload salt: %"PRIu64"\n", salt);
         } else {
-            printf("data%i: [hidden] %s %"PRIu64"\n", 0, zklaim_parse_op(cur->pl.data0_op), cur->pl.data0_ref);
-            printf("data%i: [hidden] %s %"PRIu64"\n", 1, zklaim_parse_op(cur->pl.data1_op), cur->pl.data1_ref);
-            printf("data%i: [hidden] %s %"PRIu64"\n", 2, zklaim_parse_op(cur->pl.data2_op), cur->pl.data2_ref);
-            printf("data%i: [hidden] %s %"PRIu64"\n", 3, zklaim_parse_op(cur->pl.data3_op), cur->pl.data3_ref);
-            printf("data%i: [hidden] %s %"PRIu64"\n", 4, zklaim_parse_op(cur->pl.data4_op), cur->pl.data4_ref);
+            for (int i = 0; i < ZKLAIM_MAX_PAYLOAD_ATTRIBUTES; i++)
+                printf("data%i: [hidden] %s %"PRIu64"\n", i, zklaim_parse_op(cur->pl.data_op[i]), cur->pl.data_ref[i]);
             printf("payload salt: [hidden]\n");
         }
         printf("Hash: ");

--- a/zklaim/zklaim.h
+++ b/zklaim/zklaim.h
@@ -39,6 +39,7 @@
 #define ZKLAIM_ERROR 1
 #define ZKLAIM_INVALID_SIGNATURE 2
 #define ZKLAIM_INVALID_PROOF 3
+#define ZKLAIM_MAX_PAYLOAD_ATTRIBUTES 5
 
 // enum specifying the operations of zklaim comparisons
 enum zklaim_op {
@@ -61,16 +62,8 @@ typedef struct zklaim_proof zklaim_proof;
 typedef struct zklaim_header zklaim_header;
 
 struct zklaim_payload {
-    uint64_t data0_ref;
-    enum zklaim_op data0_op;
-    uint64_t data1_ref;
-    enum zklaim_op data1_op;
-    uint64_t data2_ref;
-    enum zklaim_op data2_op;
-    uint64_t data3_ref;
-    enum zklaim_op data3_op;
-    uint64_t data4_ref;
-    enum zklaim_op data4_op;
+    uint64_t data_ref[ZKLAIM_MAX_PAYLOAD_ATTRIBUTES];
+    enum zklaim_op data_op[ZKLAIM_MAX_PAYLOAD_ATTRIBUTES];
     uint64_t salt;
     unsigned char hash[32];
     uint8_t priv;

--- a/zklaim/zklaim_gadget.cpp
+++ b/zklaim/zklaim_gadget.cpp
@@ -123,24 +123,18 @@ r1cs_primary_input<FieldT> zklaim_input_map(zklaim_ctx *ctx)
     while (cur != NULL) {
         // construct reference buf
         memset(refs, 0, 512);
-        memcpy(refs, &cur->pl.data0_ref, 8);
-        memcpy(refs+8, &cur->pl.data1_ref, 8);
-        memcpy(refs+16, &cur->pl.data2_ref, 8);
-        memcpy(refs+24, &cur->pl.data3_ref, 8);
-        memcpy(refs+32, &cur->pl.data4_ref, 8);
+        memcpy(refs, &cur->pl.data_ref[0], 8);
+        memcpy(refs+8, &cur->pl.data_ref[1], 8);
+        memcpy(refs+16, &cur->pl.data_ref[2], 8);
+        memcpy(refs+24, &cur->pl.data_ref[3], 8);
+        memcpy(refs+32, &cur->pl.data_ref[4], 8);
 
         memset(ops, 0, 512);
-        set_zklaim_ops(ops, cur->pl.data0_op);
-        set_zklaim_ops(ops+8, cur->pl.data1_op);
-        set_zklaim_ops(ops+16, cur->pl.data2_op);
-        set_zklaim_ops(ops+24, cur->pl.data3_op);
-        set_zklaim_ops(ops+32, cur->pl.data4_op);
-
-        //memcpy(ops, &cur->pl.data0_op, sizeof(cur->pl.data0_op));
-        //memcpy(ops+8, &cur->pl.data0_op, sizeof(cur->pl.data0_op));
-        //memcpy(ops+16, &cur->pl.data0_op, sizeof(cur->pl.data0_op));
-        //memcpy(ops+24, &cur->pl.data0_op, sizeof(cur->pl.data0_op));
-        //memcpy(ops+32, &cur->pl.data0_op, sizeof(cur->pl.data0_op));
+        set_zklaim_ops(ops, cur->pl.data_op[0]);
+        set_zklaim_ops(ops+8, cur->pl.data_op[1]);
+        set_zklaim_ops(ops+16, cur->pl.data_op[2]);
+        set_zklaim_ops(ops+24, cur->pl.data_op[3]);
+        set_zklaim_ops(ops+32, cur->pl.data_op[4]);
 
         h = memtobv(cur->pl.hash, 256);
         refs_vec = memtobv(refs, 512);
@@ -720,18 +714,18 @@ class zklaim_gadget : public gadget<FieldT> {
             unsigned char ops[512];
             while (cur != NULL) {
                 memset(ref_in, 0, sizeof(ref_in));
-                memcpy(ref_in, &cur->pl.data0_ref, 8);
-                memcpy(ref_in+8, &cur->pl.data1_ref, 8);
-                memcpy(ref_in+16, &cur->pl.data2_ref, 8);
-                memcpy(ref_in+24, &cur->pl.data3_ref, 8);
-                memcpy(ref_in+32, &cur->pl.data4_ref, 8);
+                memcpy(ref_in, &cur->pl.data_ref[0], 8);
+                memcpy(ref_in+8, &cur->pl.data_ref[1], 8);
+                memcpy(ref_in+16, &cur->pl.data_ref[2], 8);
+                memcpy(ref_in+24, &cur->pl.data_ref[3], 8);
+                memcpy(ref_in+32, &cur->pl.data_ref[4], 8);
 
                 memset(ops, 0, 512);
-                set_zklaim_ops(ops, cur->pl.data0_op);
-                set_zklaim_ops(ops+8, cur->pl.data1_op);
-                set_zklaim_ops(ops+16, cur->pl.data2_op);
-                set_zklaim_ops(ops+24, cur->pl.data3_op);
-                set_zklaim_ops(ops+32, cur->pl.data4_op);
+                set_zklaim_ops(ops, cur->pl.data_op[0]);
+                set_zklaim_ops(ops+8, cur->pl.data_op[1]);
+                set_zklaim_ops(ops+16, cur->pl.data_op[2]);
+                set_zklaim_ops(ops+24, cur->pl.data_op[3]);
+                set_zklaim_ops(ops+32, cur->pl.data_op[4]);
                 //memcpy(ops, &cur->pl.data0_op, sizeof(cur->pl.data0_op));
                 //memcpy(ops+8, &cur->pl.data1_op, sizeof(cur->pl.data0_op));
                 //memcpy(ops+16, &cur->pl.data1_op, sizeof(cur->pl.data0_op));


### PR DESCRIPTION
Some code internally could also be streamlined to loop over array instead of using individual variables.